### PR TITLE
Fix `as_abstract_value`.

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -319,9 +319,7 @@ def join_pvals(pval1, pval2):
 def as_abstract_val(pv):
   if isinstance(pv, AbstractValue):
     return pv
-  elif isinstance(pv, JaxprTracerTuple):
-    return AbstractTuple(map(as_abstract_val, pv))
-  elif pv is None:
+  else:
     raise TypeError("{} is not abstract".format(pv))
 
 def partial_val_aval(pv, const):


### PR DESCRIPTION
The `JaxprTracerTuple` appears to no longer exist and the function could return `None` if `pv` was another type other than `AbstractValue`, instead of raising an error.